### PR TITLE
Change order of javascript execution

### DIFF
--- a/import/guildimporter.php
+++ b/import/guildimporter.php
@@ -148,11 +148,6 @@ class guildImporter extends page_generic {
 			}
 
 			$this->tpl->add_js('
-				$( "#progressbar" ).progressbar({
-					value: 0
-				});
-				getData();', 'docready');
-			$this->tpl->add_js('
 			var guilddataArry = $.parseJSON(\''.json_encode($jsondata, JSON_HEX_APOS).'\');
 			function getData(i){
 				if (!i)
@@ -179,6 +174,11 @@ class guildImporter extends page_generic {
 					});
 				}
 			}');
+			$this->tpl->add_js('
+				$( "#progressbar" ).progressbar({
+					value: 0
+				});
+				getData();', 'docready');
 		}else{
 			$hmtlout .= '<div class="infobox infobox-large infobox-red clearfix"><i class="fa fa-exclamation-triangle fa-4x pull-left"></i> <span id="error_message_txt">'.$guilddata['reason'].'</span></div>';
 		}


### PR DESCRIPTION
I found a bug where the getData method would be hit before the guilddataArry has been set which made it undefined.

By moving it down after the deceleration of the variable we can make sure the guilddataArry variable is set before running the getData() function
